### PR TITLE
fix python-pycryptodomex depend

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-rosbag
 	pkgdesc = ROS - This is a set of tools for recording from and playing back to ROS topics.
 	pkgver = 1.14.10
-	pkgrel = 3
+	pkgrel = 4
 	url = https://wiki.ros.org/rosbag
 	arch = i686
 	arch = x86_64
@@ -35,7 +35,7 @@ pkgbase = ros-melodic-rosbag
 	depends = python-rospkg
 	depends = boost1.69
 	depends = python-gnupg
-	depends = python-crypto
+	depends = python-pycryptodomex
 	source = ros-melodic-rosbag-1.14.10.tar.gz::https://github.com/ros/ros_comm/archive/1.14.10.tar.gz
 	sha256sums = b3b75612feb447afe70600e3ba80bf3e356493a058ba8ebf2746e8db0c55165c
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/rosbag'
 pkgname='ros-melodic-rosbag'
 pkgver='1.14.10'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=3
+pkgrel=4
 license=('BSD')
 
 ros_makedepends=(
@@ -47,7 +47,7 @@ depends=(
 	python-rospkg
 	boost1.69
 	python-gnupg
-	python-crypto
+	python-pycryptodomex
 )
 
 _dir="ros_comm-${pkgver}/tools/rosbag"


### PR DESCRIPTION
Corrects depends to fix [#3](https://github.com/ros-melodic-arch/ros-melodic-rosbag/issues/3)